### PR TITLE
ENH: 清理死代码并统一命名规范

### DIFF
--- a/bits_button.c
+++ b/bits_button.c
@@ -686,7 +686,7 @@ static void bits_btn_report_event(struct button_obj_t* button, bits_btn_result_t
 
 #ifndef BITS_BTN_DISABLE_BUFFER
     uint8_t is_user_result_filter_exist = (bits_btn_result_user_filter_cb != NULL);
-    uint8_t default_result_filter_triger = (result->event == BTN_EVENT_LONG_PRESS) || (result->event == BTN_EVENT_FINISH);
+    uint8_t default_result_filter_trigger = (result->event == BTN_EVENT_LONG_PRESS) || (result->event == BTN_EVENT_FINISH);
 
     if (bits_btn_buffer_ops && bits_btn_buffer_ops->write)
     {
@@ -698,7 +698,7 @@ static void bits_btn_report_event(struct button_obj_t* button, bits_btn_result_t
         }
         else
         {
-            should_write_to_buffer = default_result_filter_triger;
+            should_write_to_buffer = default_result_filter_trigger;
         }
 
         if (should_write_to_buffer)
@@ -768,7 +768,7 @@ static void update_button_state_machine(struct button_obj_t* button, uint8_t btn
                 button->long_press_period_trigger_cnt = 0;
                 button->current_state = BTN_STATE_RELEASE;
             }
-            else if(time_diff * BITS_BTN_TICKS_INTERVAL > button->param->long_press_period_triger_ms)
+            else if(time_diff * BITS_BTN_TICKS_INTERVAL > button->param->long_press_period_trigger_ms)
             {
                 button->state_entry_time = current_time;
                 button->long_press_period_trigger_cnt++;

--- a/bits_button.h
+++ b/bits_button.h
@@ -50,13 +50,13 @@ typedef enum {
 #endif
 
 #ifndef BITS_BTN_DEBOUNCE_TIME_MS
-#define BITS_BTN_DEBOUNCE_TIME_MS            (40)
+#define BITS_BTN_DEBOUNCE_TIME_MS             (40)
 #endif
 
-#define BITS_BTN_SHORT_TIME_MS               (350)
-#define BITS_BTN_LONG_PRESS_START_TIME_MS    (1000)
-#define BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS (1000)
-#define BITS_BTN_TIME_WINDOW_TIME_MS         (300)
+#define BITS_BTN_SHORT_TIME_MS                (350)
+#define BITS_BTN_LONG_PRESS_START_TIME_MS     (1000)
+#define BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS (1000)
+#define BITS_BTN_TIME_WINDOW_TIME_MS          (300)
 
 #define BITS_BTN_NONE_PRESS_KV              0
 #define BITS_BTN_SINGLE_CLICK_KV            0b010
@@ -65,9 +65,9 @@ typedef enum {
 #define BITS_BTN_SINGLE_CLICK_THEN_LONG_PRESS_KV     0b01011
 #define BITS_BTN_DOUBLE_CLICK_THEN_LONG_PRESS_KV     0b0101011
 
-#define BITS_BTN_LONG_PRESEE_START_KV       0b011
-#define BITS_BTN_LONG_PRESEE_HOLD_KV        0b0111
-#define BITS_BTN_LONG_PRESEE_HOLD_END_KV    0b01110
+#define BITS_BTN_LONG_PRESS_START_KV       0b011
+#define BITS_BTN_LONG_PRESS_HOLD_KV        0b0111
+#define BITS_BTN_LONG_PRESS_HOLD_END_KV    0b01110
 
 
 #ifndef ARRAY_SIZE
@@ -107,7 +107,7 @@ typedef struct bits_btn_obj_param
 {
     uint16_t short_press_time_ms;
     uint16_t long_press_start_time_ms;
-    uint16_t long_press_period_triger_ms;
+    uint16_t long_press_period_trigger_ms;
     uint16_t time_window_time_ms;
 } bits_btn_obj_param_t;
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,7 +175,7 @@ typedef struct bits_btn_obj_param
 {
     uint16_t short_press_time_ms;                        // 短按时间(ms)
     uint16_t long_press_start_time_ms;                   // 长按开始时间(ms)
-    uint16_t long_press_period_triger_ms;                // 长按周期触发时间(ms)
+    uint16_t long_press_period_trigger_ms;                // 长按周期触发时间(ms)
     uint16_t time_window_time_ms;                        // 时间窗口时间(ms)
 } bits_btn_obj_param_t;
 ```

--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -57,16 +57,16 @@ typedef enum
 } user_button_t;
 
 // 2. 定义按键参数、单按键实例、组合按键实例
-static const bits_btn_obj_param_t defaul_param = {.long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
                                                   .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 
 button_obj_t btns[] =
 {
-    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &defaul_param),
-    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &defaul_param),
-    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &defaul_param),
+    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &default_param),
+    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &default_param),
+    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &default_param),
 };
 
 button_obj_combo_t btns_combo[] =
@@ -74,7 +74,7 @@ button_obj_combo_t btns_combo[] =
     BITS_BUTTON_COMBO_INIT(
         USER_BUTTON_COMBO_0,    // 组合键ID
         1,                      // 有效电平
-        &defaul_param,          // 参数配置
+        &default_param,          // 参数配置
         ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1}),   // 组合按键成员
         2,                      // 组合键成员数量
         1),                     // 抑制单键事件
@@ -228,15 +228,15 @@ typedef enum
 } user_button_t;
 
 // 2. 定义按键参数、单按键实例、组合按键实例
-static const bits_btn_obj_param_t defaul_param = {.long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
                                                   .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 button_obj_t btns[] =
 {
-    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &defaul_param),
-    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &defaul_param),
-    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &defaul_param),
+    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &default_param),
+    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &default_param),
+    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &default_param),
 };
 
 button_obj_combo_t btns_combo[] =
@@ -244,7 +244,7 @@ button_obj_combo_t btns_combo[] =
     BITS_BUTTON_COMBO_INIT(
         USER_BUTTON_COMBO_0,    // 组合键ID
         1,                      // 有效电平
-        &defaul_param,          // 参数配置
+        &default_param,          // 参数配置
         ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1}),   // 组合按键成员
         2,                      // 组合键成员数量
         1),                     // 抑制单键事件

--- a/examples/example_callback.c
+++ b/examples/example_callback.c
@@ -24,16 +24,16 @@ typedef enum
 } user_button_t;
 
 // 2. 定义按键参数、单按键实例、组合按键实例
-static const bits_btn_obj_param_t defaul_param = {.long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
                                                   .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 
 button_obj_t btns[] =
 {
-    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &defaul_param),
-    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &defaul_param),
-    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &defaul_param),
+    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &default_param),
+    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &default_param),
+    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &default_param),
 };
 
 button_obj_combo_t btns_combo[] =
@@ -41,7 +41,7 @@ button_obj_combo_t btns_combo[] =
     BITS_BUTTON_COMBO_INIT(
         USER_BUTTON_COMBO_0,    // 组合键ID
         1,                      // 有效电平
-        &defaul_param,          // 参数配置
+        &default_param,          // 参数配置
         ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1}),   // 组合按键成员
         2,                      // 组合键成员数量
         1),                     // 抑制单键事件

--- a/examples/example_poll.c
+++ b/examples/example_poll.c
@@ -24,15 +24,15 @@ typedef enum
 } user_button_t;
 
 // 2. 定义按键参数、单按键实例、组合按键实例
-static const bits_btn_obj_param_t defaul_param = {.long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
                                                   .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 button_obj_t btns[] =
 {
-    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &defaul_param),
-    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &defaul_param),
-    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &defaul_param),
+    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &default_param),
+    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &default_param),
+    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &default_param),
 };
 
 button_obj_combo_t btns_combo[] =
@@ -40,7 +40,7 @@ button_obj_combo_t btns_combo[] =
     BITS_BUTTON_COMBO_INIT(
         USER_BUTTON_COMBO_0,    // 组合键ID
         1,                      // 有效电平
-        &defaul_param,          // 参数配置
+        &default_param,          // 参数配置
         ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1}),   // 组合按键成员
         2,                      // 组合键成员数量
         1),                     // 抑制单键事件

--- a/simulator/adapter_layer/button_adapter.c
+++ b/simulator/adapter_layer/button_adapter.c
@@ -46,23 +46,23 @@ int my_log_printf(const char* format, ...) {
     return result;
 }
 
-static const bits_btn_obj_param_t defaul_param = {.long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
                                                   .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 button_obj_t btns[] =
 {
-    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &defaul_param),
-    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &defaul_param),
-    BITS_BUTTON_INIT(USER_BUTTON_2, 1, &defaul_param),
-    BITS_BUTTON_INIT(USER_BUTTON_3, 1, &defaul_param),
-    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &defaul_param),
+    BITS_BUTTON_INIT(USER_BUTTON_0, 1, &default_param),
+    BITS_BUTTON_INIT(USER_BUTTON_1, 1, &default_param),
+    BITS_BUTTON_INIT(USER_BUTTON_2, 1, &default_param),
+    BITS_BUTTON_INIT(USER_BUTTON_3, 1, &default_param),
+    // BITS_BUTTON_INIT(USER_BUTTON_2, 1, &default_param),
 };
 
 button_obj_combo_t btns_combo[] =
 {
-    BITS_BUTTON_COMBO_INIT(USER_BUTTON_COMBO_0, 1, &defaul_param, ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1}), 2, 1),
-    BITS_BUTTON_COMBO_INIT(USER_BUTTON_COMBO_1, 1, &defaul_param, ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1, USER_BUTTON_3}), 3, 1),
+    BITS_BUTTON_COMBO_INIT(USER_BUTTON_COMBO_0, 1, &default_param, ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1}), 2, 1),
+    BITS_BUTTON_COMBO_INIT(USER_BUTTON_COMBO_1, 1, &default_param, ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1, USER_BUTTON_3}), 3, 1),
 };
 
 void bits_btn_result_cb(struct button_obj_t *btn, struct bits_btn_result result)

--- a/test/cases/basic/test_initialization.c
+++ b/test/cases/basic/test_initialization.c
@@ -98,7 +98,7 @@ void test_custom_parameters(void) {
     static const bits_btn_obj_param_t custom_param = {
         .short_press_time_ms = 200,       // 自定义短按时间
         .long_press_start_time_ms = 1500, // 自定义长按时间（稍短一些）
-        .long_press_period_triger_ms = 500, // 自定义长按周期
+        .long_press_period_trigger_ms = 500, // 自定义长按周期
         .time_window_time_ms = 400        // 自定义时间窗口（稍短一些）
     };
     

--- a/test/cases/basic/test_single_operations.c
+++ b/test/cases/basic/test_single_operations.c
@@ -127,7 +127,7 @@ void test_long_press_event(void) {
     time_simulate_time_window_end();
 
     // 验证长按开始事件
-    ASSERT_EVENT_WITH_VALUE(1, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESEE_START_KV);
+    ASSERT_EVENT_WITH_VALUE(1, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESS_START_KV);
     printf("长按测试通过\n");
 }
 
@@ -138,7 +138,7 @@ void test_long_press_hold_event(void) {
     
     // 创建按键对象，设置较短的长按周期
     static const bits_btn_obj_param_t param = {
-        .long_press_period_triger_ms = 500,
+        .long_press_period_trigger_ms = 500,
         .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
         .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
         .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS

--- a/test/cases/basic/test_state_reset.c
+++ b/test/cases/basic/test_state_reset.c
@@ -35,7 +35,7 @@ void test_state_reset_functionality(void) {
     time_simulate_long_press_threshold();
     
     // 验证长按事件
-    ASSERT_EVENT_WITH_VALUE(1, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESEE_START_KV);
+    ASSERT_EVENT_WITH_VALUE(1, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESS_START_KV);
     printf("✓ 长按状态确认: 按键ID=1, 事件=2\n");
     
     // 3. 调用状态重置函数
@@ -104,7 +104,7 @@ void test_combo_button_reset(void) {
     time_simulate_long_press_threshold();
     
     // 验证组合按键长按事件
-    ASSERT_EVENT_WITH_VALUE(100, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESEE_START_KV);
+    ASSERT_EVENT_WITH_VALUE(100, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESS_START_KV);
     printf("✓ 组合按键长按状态确认: 按键ID=100, 事件=2\n");
     
     // 5. 调用状态重置函数

--- a/test/cases/compat/test_cpp_compat.cpp
+++ b/test/cases/compat/test_cpp_compat.cpp
@@ -13,7 +13,7 @@ namespace test_namespace {
         const bits_btn_obj_param_t param = {
             .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
             .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-            .long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+            .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS
         };
 
@@ -34,7 +34,7 @@ public:
         param = {
             .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
             .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-            .long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+            .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS
         };
 
@@ -95,7 +95,7 @@ int main() {
         const bits_btn_obj_param_t test_param = {
             .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
             .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-            .long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+            .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS
         };
 
@@ -129,7 +129,7 @@ int main() {
         uint32_t time_values[] = {
             BITS_BTN_SHORT_TIME_MS,
             BITS_BTN_LONG_PRESS_START_TIME_MS,
-            BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
+            BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             BITS_BTN_TIME_WINDOW_TIME_MS,
             BITS_BTN_DEBOUNCE_TIME_MS,
             BITS_BTN_TICKS_INTERVAL
@@ -141,9 +141,9 @@ int main() {
             BITS_BTN_DOUBLE_CLICK_KV,
             BITS_BTN_SINGLE_CLICK_THEN_LONG_PRESS_KV,
             BITS_BTN_DOUBLE_CLICK_THEN_LONG_PRESS_KV,
-            BITS_BTN_LONG_PRESEE_START_KV,
-            BITS_BTN_LONG_PRESEE_HOLD_KV,
-            BITS_BTN_LONG_PRESEE_HOLD_END_KV
+            BITS_BTN_LONG_PRESS_START_KV,
+            BITS_BTN_LONG_PRESS_HOLD_KV,
+            BITS_BTN_LONG_PRESS_HOLD_END_KV
         };
         (void)time_values;
         (void)key_values;

--- a/test/cases/edge/test_error_handling.c
+++ b/test/cases/edge/test_error_handling.c
@@ -123,7 +123,7 @@ void test_boundary_values(void) {
     static const bits_btn_obj_param_t extreme_param = {
         .short_press_time_ms = 1,           // 极短时间
         .long_press_start_time_ms = 65535,  // 极长时间
-        .long_press_period_triger_ms = 1,   // 极短周期
+        .long_press_period_trigger_ms = 1,   // 极短周期
         .time_window_time_ms = 65535        // 极长窗口
     };
 

--- a/test/cases/edge/test_state_machine_edge.c
+++ b/test/cases/edge/test_state_machine_edge.c
@@ -113,7 +113,7 @@ void test_long_press_period_boundary(void) {
     ASSERT_EVENT_EXISTS(1, BTN_EVENT_LONG_PRESS);
     
     // 等待长按周期触发 - 需要额外的时间来触发周期事件
-    time_simulate_pass(param.long_press_period_triger_ms + 50);
+    time_simulate_pass(param.long_press_period_trigger_ms + 50);
     
     // 检查是否有长按保持事件（long_press_period_trigger_cnt > 0）
     bits_btn_result_t* events = test_framework_get_events();

--- a/test/config/test_config.h
+++ b/test/config/test_config.h
@@ -31,14 +31,14 @@
 
 // ==================== 测试参数宏 ====================
 #define TEST_DEFAULT_PARAM() { \
-    .long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS, \
+    .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS, \
     .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS, \
     .short_press_time_ms = BITS_BTN_SHORT_TIME_MS, \
     .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS \
 }
 
 #define TEST_FAST_LONG_PRESS_PARAM() { \
-    .long_press_period_triger_ms = 500, \
+    .long_press_period_trigger_ms = 500, \
     .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS, \
     .short_press_time_ms = BITS_BTN_SHORT_TIME_MS, \
     .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS \
@@ -62,7 +62,7 @@
     ASSERT_EVENT_WITH_VALUE(key_id, BTN_EVENT_FINISH, 0b101010)  // 三连击: 010 + 010 + 10
 
 #define VERIFY_LONG_PRESS_START(key_id) \
-    ASSERT_EVENT_WITH_VALUE(key_id, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESEE_START_KV)
+    ASSERT_EVENT_WITH_VALUE(key_id, BTN_EVENT_LONG_PRESS, BITS_BTN_LONG_PRESS_START_KV)
 
 #define VERIFY_SINGLE_THEN_LONG_PRESS(key_id) \
     ASSERT_EVENT_WITH_VALUE(key_id, BTN_EVENT_LONG_PRESS, BITS_BTN_SINGLE_CLICK_THEN_LONG_PRESS_KV)

--- a/test/test_main_new.c
+++ b/test/test_main_new.c
@@ -75,40 +75,6 @@ extern void test_peek_functionality(void);
 extern void test_peek_vs_get_behavior(void);
 extern void test_peek_disabled_buffer_mode(void);
 
-// ==================== 测试套件设置函数 ====================
-
-void basic_tests_setup(void) {
-    test_framework_reset();
-}
-
-void basic_tests_teardown(void) {
-    // 基础测试清理
-}
-
-void combo_tests_setup(void) {
-    test_framework_reset();
-}
-
-void combo_tests_teardown(void) {
-    // 组合测试清理
-}
-
-void edge_tests_setup(void) {
-    test_framework_reset();
-}
-
-void edge_tests_teardown(void) {
-    // 边界测试清理
-}
-
-void performance_tests_setup(void) {
-    test_framework_reset();
-}
-
-void performance_tests_teardown(void) {
-    // 性能测试清理
-}
-
 // ==================== Unity标准设置函数 ====================
 
 // 定义最大失败记录数（200个足够容纳所有测试用例）


### PR DESCRIPTION
What:
1. 删除 test_main_new.c 中从未被调用的 8 个测试 setup/teardown 函数；
2. 修复代码拼写错误：PRESEE→PRESS、triger→trigger、defaul_param→default_param