### PR TITLE
FIX: 移除未使用的 short_press_time_ms 字段及 BITS_BTN_SHORT_TIME_MS 宏

### DIFF
--- a/bits_button.h
+++ b/bits_button.h
@@ -53,7 +53,6 @@ typedef enum {
 #define BITS_BTN_DEBOUNCE_TIME_MS             (40)
 #endif
 
-#define BITS_BTN_SHORT_TIME_MS                (350)
 #define BITS_BTN_LONG_PRESS_START_TIME_MS     (1000)
 #define BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS (1000)
 #define BITS_BTN_TIME_WINDOW_TIME_MS          (300)
@@ -105,7 +104,6 @@ typedef struct bits_btn_result
 
 typedef struct bits_btn_obj_param
 {
-    uint16_t short_press_time_ms;
     uint16_t long_press_start_time_ms;
     uint16_t long_press_period_trigger_ms;
     uint16_t time_window_time_ms;

--- a/docs/api.md
+++ b/docs/api.md
@@ -173,7 +173,6 @@ typedef struct button_obj_t {
 ```c
 typedef struct bits_btn_obj_param
 {
-    uint16_t short_press_time_ms;                        // 短按时间(ms)
     uint16_t long_press_start_time_ms;                   // 长按开始时间(ms)
     uint16_t long_press_period_trigger_ms;                // 长按周期触发时间(ms)
     uint16_t time_window_time_ms;                        // 时间窗口时间(ms)

--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -45,7 +45,7 @@ BitsButton 的核心是一个基于时间窗口（Time Window）的有限状态�
 ### 关键机制说明
 
 1. **消抖处理（Debounce）**：
-   - 物理按下必须持续超过 `short_press_time_ms` 才会进入 `PRESSED` 状态。小于此时间的抖动会被丢弃。
+   - 物理按下必须持续超过 `BITS_BTN_DEBOUNCE_TIME_MS`（默认 40ms）才会进入 `PRESSED` 状态。小于此时间的抖动会被丢弃。该宏可在编译时覆盖。
 2. **多击判定窗口（Release Window）**：
    - 当用户松开按键（`RELEASE`）时，系统**不会立即判定动作结束**，而是进入等待窗口。
    - 只有在 `time_window_time_ms` 时间内没有新的按下动作，系统才会抛出终结事件 `BTN_EVENT_FINISH`。
@@ -101,7 +101,6 @@ typedef enum
 // 2. 定义按键参数、单按键实例、组合按键实例
 static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-                                                  .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 
 button_obj_t btns[] =
@@ -272,7 +271,6 @@ typedef enum
 // 2. 定义按键参数、单按键实例、组合按键实例
 static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-                                                  .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 button_obj_t btns[] =
 {

--- a/examples/example_callback.c
+++ b/examples/example_callback.c
@@ -26,7 +26,6 @@ typedef enum
 // 2. 定义按键参数、单按键实例、组合按键实例
 static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-                                                  .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 
 button_obj_t btns[] =

--- a/examples/example_poll.c
+++ b/examples/example_poll.c
@@ -26,7 +26,6 @@ typedef enum
 // 2. 定义按键参数、单按键实例、组合按键实例
 static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-                                                  .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 button_obj_t btns[] =
 {

--- a/simulator/adapter_layer/button_adapter.c
+++ b/simulator/adapter_layer/button_adapter.c
@@ -48,7 +48,6 @@ int my_log_printf(const char* format, ...) {
 
 static const bits_btn_obj_param_t default_param = {.long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
                                                   .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-                                                  .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
                                                   .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 button_obj_t btns[] =
 {

--- a/test/cases/basic/test_initialization.c
+++ b/test/cases/basic/test_initialization.c
@@ -96,7 +96,6 @@ void test_custom_parameters(void) {
     
     // 创建自定义参数 - 使用更合理的参数值
     static const bits_btn_obj_param_t custom_param = {
-        .short_press_time_ms = 200,       // 自定义短按时间
         .long_press_start_time_ms = 1500, // 自定义长按时间（稍短一些）
         .long_press_period_trigger_ms = 500, // 自定义长按周期
         .time_window_time_ms = 400        // 自定义时间窗口（稍短一些）

--- a/test/cases/basic/test_single_operations.c
+++ b/test/cases/basic/test_single_operations.c
@@ -140,7 +140,6 @@ void test_long_press_hold_event(void) {
     static const bits_btn_obj_param_t param = {
         .long_press_period_trigger_ms = 500,
         .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-        .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
         .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS
     };
     

--- a/test/cases/compat/test_cpp_compat.cpp
+++ b/test/cases/compat/test_cpp_compat.cpp
@@ -11,7 +11,6 @@ namespace test_namespace {
     // 测试在命名空间中使用库
     static void test_in_namespace() {
         const bits_btn_obj_param_t param = {
-            .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
             .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
             .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS
@@ -32,7 +31,6 @@ public:
     ButtonManager() {
         // 测试在构造函数中初始化
         param = {
-            .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
             .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
             .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS
@@ -93,7 +91,6 @@ int main() {
         // 1. 基本结构体初始化测试
         std::cout << "1. 测试基本结构体初始化..." << std::endl;
         const bits_btn_obj_param_t test_param = {
-            .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
             .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
             .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS
@@ -127,7 +124,6 @@ int main() {
         // 5. 所有宏定义可用性测试
         std::cout << "5. 测试宏定义..." << std::endl;
         uint32_t time_values[] = {
-            BITS_BTN_SHORT_TIME_MS,
             BITS_BTN_LONG_PRESS_START_TIME_MS,
             BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS,
             BITS_BTN_TIME_WINDOW_TIME_MS,
@@ -193,8 +189,7 @@ int main() {
 
         // 基本验证
         if (test_button.key_id == 1 &&
-            test_combo.key_count == 2 &&
-            test_param.short_press_time_ms == BITS_BTN_SHORT_TIME_MS) {
+            test_combo.key_count == 2) {
             std::cout << "🎉 所有C++兼容性测试通过！" << std::endl;
             return 0;  // 成功
         } else {

--- a/test/cases/edge/test_error_handling.c
+++ b/test/cases/edge/test_error_handling.c
@@ -121,7 +121,6 @@ void test_boundary_values(void) {
 
     // 测试极端的参数值
     static const bits_btn_obj_param_t extreme_param = {
-        .short_press_time_ms = 1,           // 极短时间
         .long_press_start_time_ms = 65535,  // 极长时间
         .long_press_period_trigger_ms = 1,   // 极短周期
         .time_window_time_ms = 65535        // 极长窗口

--- a/test/config/test_config.h
+++ b/test/config/test_config.h
@@ -33,14 +33,12 @@
 #define TEST_DEFAULT_PARAM() { \
     .long_press_period_trigger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGGER_MS, \
     .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS, \
-    .short_press_time_ms = BITS_BTN_SHORT_TIME_MS, \
     .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS \
 }
 
 #define TEST_FAST_LONG_PRESS_PARAM() { \
     .long_press_period_trigger_ms = 500, \
     .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS, \
-    .short_press_time_ms = BITS_BTN_SHORT_TIME_MS, \
     .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS \
 }
 


### PR DESCRIPTION
Why:
1. short_press_time_ms 字段在代码中从未被读取，实际消抖由全局宏 BITS_BTN_DEBOUNCE_TIME_MS（40ms）控制；
2. 该字段在文档中被错误描述为消抖参数，误导用户以为可通过它控制消抖行为；
3. 删除头文件中的宏定义和结构体字段，同步清理 docs、examples、simulator、test 共 13 个文件中的所有引用；
4. 修正 usage_guide.md 消抖机制描述，指向真正生效的 BITS_BTN_DEBOUNCE_TIME_MS

TEST: 48 Tests 0 Failures 0 Ignored